### PR TITLE
Fix for spaces in project name causing macOS builds from Windows to fail

### DIFF
--- a/source/Steamworks_gml/extensions/steamworks/post_build_step.bat
+++ b/source/Steamworks_gml/extensions/steamworks/post_build_step.bat
@@ -79,7 +79,7 @@ exit /b 0
     ) else (
 
         :: This is used from YYC compilation
-        call %Utils% fileCopyTo %SDK_SOURCE% "%YYprojectName%\%YYprojectName%\Supporting Files\libsteam_api.dylib"
+        call %Utils% fileCopyTo %SDK_SOURCE% "%YYprojectName: =_%\%YYprojectName: =_%\Supporting Files\libsteam_api.dylib"
     )
 
     if defined DEBUG_MODE (


### PR DESCRIPTION
macOS build converts spaces to underscores in its project directory names. Compensate for that when copying libsteam_api.dylib from Windows.