### PR TITLE
Fixed that scriptUtils.bat fails when Igor.exe invoked from newer versions of powershell

### DIFF
--- a/source/Steamworks_gml/extensions/steamworks/scriptUtils.bat
+++ b/source/Steamworks_gml/extensions/steamworks/scriptUtils.bat
@@ -6,6 +6,7 @@ shift & goto :%~1
 :scriptInit
     set "LOG_LABEL=UNSET"
     set "LOG_LEVEL=-1"
+    set PSModulePath=
 
     call :assertPowerShellExecutionPolicy
 


### PR DESCRIPTION
This PR is a bugfix for the following issue

https://github.com/YoYoGames/GMEXT-Steamworks/issues/120
