### PR TITLE
Workaround bug with spaces in project name

### DIFF
--- a/source/Steamworks_gml/extensions/steamworks/post_build_step.sh
+++ b/source/Steamworks_gml/extensions/steamworks/post_build_step.sh
@@ -22,6 +22,9 @@ setupmacOS() {
             YYprojectName=$(basename "${YYprojectPath%.*}")
         fi
 
+        # Replace spaces with underscores in YYprojectName
+        YYprojectName=${YYprojectName// /_}
+
         itemCopyTo "$SDK_SOURCE" "${YYprojectName}/${YYprojectName}/Supporting Files/libsteam_api.dylib"
     fi
 }


### PR DESCRIPTION
I wasn't able to get the extension working on MacOS. When I investigated what was happening, it turned out that the `libsteam_api.dylib` library was being copied to the wrong place because my project had spaces in the name.

I applied this workaround to the extension in my project which resolved the issue for me. I suspect this isn't the correct solution, but wanted to put up a PR to help demonstrate what I'm seeing.

The bug is very easy to reproduce in the sample app that ships with the extension by just importing the demo project to a new project with a space in the name.

Fixes https://github.com/YoYoGames/GMEXT-Steamworks/issues/122