### PR TITLE
Added functions for handling steam beta branches

### DIFF
--- a/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_apps.cpp
+++ b/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_apps.cpp
@@ -59,3 +59,107 @@ YYEXPORT void /*const char**/ steam_available_languages(RValue& Result, CInstanc
 	YYCreateString(&Result,SteamApps()->GetAvailableGameLanguages());
 }
 
+YYEXPORT void /*bool*/ steam_get_current_beta_name(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg)//()
+{
+	if (!steam_is_initialised)
+	{
+		Result.kind = VALUE_REAL;
+		Result.val = 0;
+		return;
+	}
+
+	char betaName[256]; // Buffer to store the beta name
+	bool success = SteamApps()->GetCurrentBetaName(betaName, 256);
+
+	if (success)
+	{
+		YYCreateString(&Result, betaName);
+	}
+	else
+	{
+		// If not on a beta branch, return empty string
+		YYCreateString(&Result, "");
+	}
+}
+
+YYEXPORT void /*int*/ steam_get_num_betas(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg)//()
+{
+    if (!steam_is_initialised)
+    {
+        Result.kind = VALUE_REAL;
+        Result.val = 0;
+        return;
+    }
+
+    int available = 0;
+    int private_betas = 0;
+    int total_betas = SteamApps()->GetNumBetas(&available, &private_betas);
+
+    // Create a DS map to return the values
+    int map = CreateDsMap(0, 0);
+    DsMapAddDouble(map, "total", total_betas);
+    DsMapAddDouble(map, "available", available);
+    DsMapAddDouble(map, "private", private_betas);
+
+    Result.kind = VALUE_REAL;
+    Result.val = map;
+}
+
+YYEXPORT void /*bool*/ steam_get_beta_info(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg)//()
+{
+    if (!steam_is_initialised || argc < 1)
+    {
+        Result.kind = VALUE_REAL;
+        Result.val = 0;
+        return;
+    }
+
+    int betaIndex = (int)(YYGetReal(arg, 0));
+
+    uint32 flags = 0;
+    uint32 buildID = 0;
+    char betaName[128];
+    char description[1024];
+
+    bool success = SteamApps()->GetBetaInfo(betaIndex, &flags, &buildID, betaName, sizeof(betaName),
+        description, sizeof(description));
+
+    if (success)
+    {
+        // Create a DS map to return all the information
+        int map = CreateDsMap(0, 0);
+        DsMapAddDouble(map, "flags", flags);
+        DsMapAddDouble(map, "buildID", buildID);
+        DsMapAddString(map, "name", betaName);
+        DsMapAddString(map, "description", description);
+        DsMapAddDouble(map, "success", 1);
+
+        Result.kind = VALUE_REAL;
+        Result.val = map;
+    }
+    else
+    {
+        // Return a map with just the success flag set to false
+        int map = CreateDsMap(0, 0);
+        DsMapAddDouble(map, "success", 0);
+
+        Result.kind = VALUE_REAL;
+        Result.val = map;
+    }
+}
+
+YYEXPORT void /*bool*/ steam_set_active_beta(RValue& Result, CInstance* selfinst, CInstance* otherinst, int argc, RValue* arg)//()
+{
+    if (!steam_is_initialised || argc < 1)
+    {
+        Result.kind = VALUE_REAL;
+        Result.val = 0;
+        return;
+    }
+
+    const char* betaName = YYGetString(arg, 0);
+    bool success = SteamApps()->SetActiveBeta(betaName);
+
+    Result.kind = VALUE_REAL;
+    Result.val = success ? 1.0 : 0.0;
+}


### PR DESCRIPTION


Added functions for steams beta branch functions:
- steam_get_current_beta_name()
- steam_get_num_betas()
- steam_get_beta_info(beta_index)
- steam_set_active_beta(beta_index)


Steam API functions:
- [GetCurrentBetaName](https://partner.steamgames.com/doc/api/ISteamApps#GetCurrentBetaName)
- [GetNumBetas](https://partner.steamgames.com/doc/api/ISteamApps#GetNumBetas)
- [GetBetaInfo](https://partner.steamgames.com/doc/api/ISteamApps#GetBetaInfo)
- [SetActiveBeta](https://partner.steamgames.com/doc/api/ISteamApps#SetActiveBeta)

Steam Article: 
[New: Steam APIs For Switching Game Versions & Beta Branches](https://steamcommunity.com/groups/steamworks/announcements/detail/4547039255696769967)

