### PR TITLE
Fix constant naming inconsistencies, #140

### DIFF
--- a/docs/networking_sockets.js
+++ b/docs/networking_sockets.js
@@ -462,7 +462,7 @@
  * 
  * This set of constants hold the types of fake IP.
  * 
- * [[Note: Alternatively, you can use the `STEAMWORKS_NET_FAKE_IP_TYPE` enum.]]
+ * [[Note: The `STEAMWORKS_NET_FAKE_IP_TYPE` enum is deprecated. Use the snake_case extension constants listed here instead.]]
  * 
  * @member steam_net_fake_ip_type_invalid Error, argument was not even an IP address, etc.
  * @member steam_net_fake_ip_type_not_fake Argument was a valid IP, but was not from the reserved "fake" range
@@ -477,7 +477,7 @@
  * 
  * This set of constants holds the different types of identities that a remote host can have. Most of the time on Steam, this will be a SteamID. However, in some cases you can disable authentication, in which case a more generic identity will be used.
  * 
- * [[Note: Alternatively, you can use the `STEAMWORKS_NET_IDENTITY_TYPE` enum.]]
+ * [[Note: The `STEAMWORKS_NET_IDENTITY_TYPE` enum is deprecated. Use the snake_case extension constants listed here instead.]]
  * 
  * @member steam_net_identity_type_invalid Dummy/unknown/invalid
  * @member steam_net_identity_type_steam_id 64-bit SteamID
@@ -495,7 +495,7 @@
  * 
  * This set of constants holds the different states of networking availability.
  * 
- * [[Note: Alternatively, you can use the `STEAMWORKS_NET_AVAILABILITY` enum.]]
+ * [[Note: The `STEAMWORKS_NET_AVAILABILITY` enum is deprecated. Use the snake_case extension constants listed here instead.]]
  * 
  * @member steam_net_availability_cannot_try A dependent resource is missing, so this service is unavailable. (E.g. we cannot talk to routers because Internet is down or we don't have the network config.)
  * @member steam_net_availability_failed We have tried for enough time that we would expect to have been successful by now. We have never been successful.
@@ -515,7 +515,7 @@
  * 
  * These constants are used in bitmask parameters to functions for message sending such as ${function.steam_net_sockets_send_message}.
  * 
- * [[Note: Alternatively, you can use the `STEAMWORKS_NET_SEND_FLAG` enum.]]
+ * [[Note: The `STEAMWORKS_NET_SEND_FLAG` enum is deprecated. Use the snake_case extension constants listed here instead.]]
  * 
  * @member steam_net_send_flag_unreliable Send the message unreliably. Can be lost. Messages *can* be larger than a single MTU (UDP packet), but there is no retransmission, so if any piece of the message is lost, the entire message will be dropped.
  * @member steam_net_send_flag_no_nagle Disable [Nagle's algorithm](https://en.wikipedia.org/wiki/Nagle%27s_algorithm).
@@ -533,7 +533,7 @@
  * 
  * This enumeration holds the possible high level connection states.
  * 
- * [[Note: Alternatively, you can use the `STEAMWORKS_NET_CONNECTION_STATE` enum.]]
+ * [[Note: The `STEAMWORKS_NET_CONNECTION_STATE` enum is deprecated. Use the snake_case extension constants listed here instead.]]
  * 
  * @member steam_net_connection_state_none Dummy value used to indicate an error condition in the API. Specified connection doesn't exist or has already been closed.
  * @member steam_net_connection_state_connecting We are trying to establish whether peers can talk to each other, whether they WANT to talk to each other, perform basic auth, and exchange crypt keys.

--- a/docs/social.js
+++ b/docs/social.js
@@ -445,7 +445,7 @@
  * 
  * This set of constants represent the different flags for enumerating the friends list, or quickly checking the relationship between users.
  * 
- * [[Note: Alternatively, you can use the `STEAMWORKS_FRIENDS_FLAGS` enum.]]
+ * [[Note: The `STEAMWORKS_FRIENDS_FLAGS` enum is deprecated. Use the snake_case extension constants listed here instead.]]
  * 
  * @member steam_friends_flags_none None.
  * @member steam_friends_flags_blocked Users that the current user has blocked from contacting.
@@ -468,7 +468,7 @@
  * 
  * This set of constants represents the list of states a Steam friend can be in.
  * 
- * [[Note: Alternatively, you can use the `STEAMWORKS_PERSONA_STATE` enum.]]
+ * [[Note: The `STEAMWORKS_PERSONA_STATE` enum is deprecated. Use the snake_case extension constants listed here instead.]]
  * 
  * @member steam_persona_state_offline Friend is not currently logged on.
  * @member steam_persona_state_online Friend is logged on.
@@ -477,7 +477,7 @@
  * @member steam_persona_state_snooze Auto-away for a long time.
  * @member steam_persona_state_looking_to_trade Online, trading.
  * @member steam_persona_state_looking_to_play Online, wanting to play.
- * @member steam_persona_state_invisible The total number of states. Only used for looping and validation.
+ * @member steam_persona_state_invisible Online, but appears offline to friends. This status is never published to clients.
  * @const_end
  */
 

--- a/source/Steamworks_gml/extensions/steamworks/docs/networking_sockets.html
+++ b/source/Steamworks_gml/extensions/steamworks/docs/networking_sockets.html
@@ -1651,7 +1651,7 @@ An IPv6 address of ::ffff:0000:0000 means "any IPv4"</p>
 <p>This set of constants hold the types of fake IP.</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>Alternatively, you can use the <code>STEAMWORKS_NET_FAKE_IP_TYPE</code> enum.</p>
+<p>The <code>STEAMWORKS_NET_FAKE_IP_TYPE</code> enum is deprecated. Use the snake_case extension constants listed here instead.</p>
 </div>
 <p>These constants are referenced by the following functions:</p>
 <ul>
@@ -1695,7 +1695,7 @@ An IPv6 address of ::ffff:0000:0000 means "any IPv4"</p>
 <p>This set of constants holds the different types of identities that a remote host can have. Most of the time on Steam, this will be a SteamID. However, in some cases you can disable authentication, in which case a more generic identity will be used.</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>Alternatively, you can use the <code>STEAMWORKS_NET_IDENTITY_TYPE</code> enum.</p>
+<p>The <code>STEAMWORKS_NET_IDENTITY_TYPE</code> enum is deprecated. Use the snake_case extension constants listed here instead.</p>
 </div>
 <p>These constants are referenced by the following functions:</p>
 <ul>
@@ -1755,7 +1755,7 @@ An IPv6 address of ::ffff:0000:0000 means "any IPv4"</p>
 <p>This set of constants holds the different states of networking availability.</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>Alternatively, you can use the <code>STEAMWORKS_NET_AVAILABILITY</code> enum.</p>
+<p>The <code>STEAMWORKS_NET_AVAILABILITY</code> enum is deprecated. Use the snake_case extension constants listed here instead.</p>
 </div>
 <p>These constants are referenced by the following functions:</p>
 <ul>
@@ -1819,7 +1819,7 @@ An IPv6 address of ::ffff:0000:0000 means "any IPv4"</p>
 <p>These constants are used in bitmask parameters to functions for message sending such as <a href="networking_sockets.html#steam_net_sockets_send_message">steam_net_sockets_send_message</a>.</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>Alternatively, you can use the <code>STEAMWORKS_NET_SEND_FLAG</code> enum.</p>
+<p>The <code>STEAMWORKS_NET_SEND_FLAG</code> enum is deprecated. Use the snake_case extension constants listed here instead.</p>
 </div>
 <p>These constants are referenced by the following functions:</p>
 <ul>
@@ -1882,7 +1882,7 @@ An IPv6 address of ::ffff:0000:0000 means "any IPv4"</p>
 <p>This enumeration holds the possible high level connection states.</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>Alternatively, you can use the <code>STEAMWORKS_NET_CONNECTION_STATE</code> enum.</p>
+<p>The <code>STEAMWORKS_NET_CONNECTION_STATE</code> enum is deprecated. Use the snake_case extension constants listed here instead.</p>
 </div>
 <p>These constants are referenced by the following functions:</p>
 <ul>

--- a/source/Steamworks_gml/extensions/steamworks/docs/social.html
+++ b/source/Steamworks_gml/extensions/steamworks/docs/social.html
@@ -1003,7 +1003,7 @@ The extended code example above shows how to properly request, wait for and iter
 <p>This set of constants represent the different flags for enumerating the friends list, or quickly checking the relationship between users.</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>Alternatively, you can use the <code>STEAMWORKS_FRIENDS_FLAGS</code> enum.</p>
+<p>The <code>STEAMWORKS_FRIENDS_FLAGS</code> enum is deprecated. Use the snake_case extension constants listed here instead.</p>
 </div>
 <p>These constants are referenced by the following functions:</p>
 <ul>
@@ -1079,7 +1079,7 @@ The extended code example above shows how to properly request, wait for and iter
 <p>This set of constants represents the list of states a Steam friend can be in.</p>
 <div class="admonition note">
 <p class="admonition-title">Note</p>
-<p>Alternatively, you can use the <code>STEAMWORKS_PERSONA_STATE</code> enum.</p>
+<p>The <code>STEAMWORKS_PERSONA_STATE</code> enum is deprecated. Use the snake_case extension constants listed here instead.</p>
 </div>
 <p>These constants are referenced by the following structs:</p>
 <ul>
@@ -1124,7 +1124,7 @@ The extended code example above shows how to properly request, wait for and iter
 </tr>
 <tr>
 <td><code>steam_persona_state_invisible</code></td>
-<td>The total number of states. Only used for looping and validation.</td>
+<td>Online, but appears offline to friends. This status is never published to clients.</td>
 </tr>
 </tbody>
 </table>

--- a/source/Steamworks_gml/objects/Obj_Steam_Friends_Info/Mouse_4.gml
+++ b/source/Steamworks_gml/objects/Obj_Steam_Friends_Info/Mouse_4.gml
@@ -1,8 +1,8 @@
 
 show_debug_message("----------------")
-show_debug_message(steam_get_friends_game_info(STEAMWORKS_FRIENDS_FLAGS.BLOCKED))
-show_debug_message(steam_get_friends_game_info(STEAMWORKS_FRIENDS_FLAGS.IMMEDIATE))//default
+show_debug_message(steam_get_friends_game_info(steam_friends_flags_blocked))
+show_debug_message(steam_get_friends_game_info(steam_friends_flags_immediate))//default
 show_debug_message(steam_get_friends_game_info())
 
 show_debug_message("----------------")
-show_debug_message(steam_get_friends(STEAMWORKS_FRIENDS_FLAGS.IMMEDIATE))
+show_debug_message(steam_get_friends(steam_friends_flags_immediate))

--- a/source/Steamworks_gml/objects/Obj_Steam_Networking_Messages/Create_0.gml
+++ b/source/Steamworks_gml/objects/Obj_Steam_Networking_Messages/Create_0.gml
@@ -7,7 +7,7 @@ text = "Net Msg"
 
 steam_net_messages_register_callbacks()
 
-var array = steam_get_friends_game_info(STEAMWORKS_FRIENDS_FLAGS.IMMEDIATE)
+var array = steam_get_friends_game_info(steam_friends_flags_immediate)
 
 var X = 100
 var Y = 150

--- a/source/Steamworks_gml/objects/Obj_Steam_Networking_Sockets_Client/Create_0.gml
+++ b/source/Steamworks_gml/objects/Obj_Steam_Networking_Sockets_Client/Create_0.gml
@@ -14,7 +14,7 @@ net_host_steamid64 = 76561199257286820//0; // set this on the client before conn
 NET_P2P_PORT = 7
 
 
-var array = steam_get_friends_game_info(STEAMWORKS_FRIENDS_FLAGS.IMMEDIATE)
+var array = steam_get_friends_game_info(steam_friends_flags_immediate)
 
 var X = 100
 var Y = 150

--- a/source/Steamworks_gml/scripts/Steamworks_Definitions/Steamworks_Definitions.gml
+++ b/source/Steamworks_gml/scripts/Steamworks_Definitions/Steamworks_Definitions.gml
@@ -1,4 +1,5 @@
 
+// @deprecated Use the steam_friends_flags_* extension constants instead.
 enum STEAMWORKS_FRIENDS_FLAGS
 {
 	NONE = 0x00,
@@ -19,6 +20,7 @@ enum STEAMWORKS_FRIENDS_FLAGS
 };
 
 
+// @deprecated Use the steam_persona_state_* extension constants instead.
 enum STEAMWORKS_PERSONA_STATE
 {
 	OFFLINE = 0,			// FRIEND IS NOT CURRENTLY LOGGED ON
@@ -36,6 +38,7 @@ enum STEAMWORKS_PERSONA_STATE
 
 
 // SteamNetworking connection states (ESteamNetworkingConnectionState)
+// @deprecated Use the steam_net_connection_state_* extension constants instead.
 enum STEAMWORKS_NET_CONNECTION_STATE
 {
 	NONE = 0,
@@ -52,6 +55,7 @@ enum STEAMWORKS_NET_CONNECTION_STATE
 
 
 // SteamNetworking send flags (k_nSteamNetworkingSend_*)
+// @deprecated Use the steam_net_send_flag_* extension constants instead.
 enum STEAMWORKS_NET_SEND_FLAG
 {
 	UNRELIABLE = 0,
@@ -66,6 +70,7 @@ enum STEAMWORKS_NET_SEND_FLAG
 }
 
 // enum ESteamNetworkingFakeIPType
+// @deprecated Use the steam_net_fake_ip_type_* extension constants instead.
 enum STEAMWORKS_NET_FAKE_IP_TYPE
 {
 	INVALID, // Error, argument was not even an IP address, etc.
@@ -76,6 +81,7 @@ enum STEAMWORKS_NET_FAKE_IP_TYPE
 
 
 /// enum ESteamNetworkingIdentityType
+// @deprecated Use the steam_net_identity_type_* extension constants instead.
 enum STEAMWORKS_NET_IDENTITY_TYPE
 {
 	// Dummy/empty/invalid.
@@ -124,6 +130,7 @@ enum STEAMWORKS_NET_IDENTITY_TYPE
 
 /// Describe the status of a particular network resource
 // enum ESteamNetworkingAvailability
+// @deprecated Use the steam_net_availability_* extension constants instead.
 enum STEAMWORKS_NET_AVAILABILITY
 {
 	// Negative values indicate a problem.
@@ -153,6 +160,7 @@ enum STEAMWORKS_NET_AVAILABILITY
 /// Enumerate various causes of connection termination.  These are designed to work similar
 /// to HTTP error codes: the numeric range gives you a rough classification as to the source
 /// of the problem.
+// @deprecated Use the steam_net_connection_end_* extension constants instead.
 enum STEAMWORKS_NET_CONNECTION_END
 {
 	// Invalid/sentinel value


### PR DESCRIPTION
Updating the documentation and codebase to mark several legacy enum types as deprecated and standardizes usage on the newer snake_case extension constants. It also updates sample code to use the new constants and clarifies the documentation for certain enum values.