### PR TITLE
Report denied lobby joins as failures

### DIFF
--- a/docs/lobbies.js
+++ b/docs/lobbies.js
@@ -248,8 +248,9 @@
  * @event steam
  * @member {string} event_type The string value `"lobby_joined"`
  * @member {int64} lobby_id The lobby unique identifier
- * @member {boolean} success Whether or not the task was successful
+ * @member {boolean} success Whether or not the lobby was entered successfully
  * @member {real} result The code of the result
+ * @member {real} enter_response The Steam `EChatRoomEnterResponse` value returned for the join attempt
  * @event_end
  * 
  * @event steam

--- a/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_matchmaking.cpp
+++ b/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_matchmaking.cpp
@@ -405,10 +405,18 @@ YYEXPORT void /*double*/ steam_lobby_list_get_lobby_member_id(RValue & Result, C
 
 CCallResult<steam_net_callbacks_t, LobbyEnter_t> steam_lobby_joined;
 void steam_net_callbacks_t::lobby_joined(LobbyEnter_t* e, bool failed) {
-	steam_lobby_current.SetFromUint64(e->m_ulSteamIDLobby);
+	int32 enterResponse = failed ? k_EChatRoomEnterResponseError : e->m_EChatRoomEnterResponse;
+	bool success = !failed && enterResponse == k_EChatRoomEnterResponseSuccess;
+	uint64 lobbyId = failed ? 0 : e->m_ulSteamIDLobby;
+	if (success)
+	{
+		steam_lobby_current.SetFromUint64(lobbyId);
+	}
+
 	steam_net_event q((char*)"lobby_joined");
-	q.set_uint64_all("lobby_id", e->m_ulSteamIDLobby);
-	q.set_success(!failed);
+	q.set_uint64_all("lobby_id", lobbyId);
+	q.set_success(success);
+	q.set((char*)"enter_response", enterResponse);
 	q.dispatch();
 }
 


### PR DESCRIPTION
Superseded by #172.

This PR was closed after the branch was renamed away from the temporary `codex/` prefix. The replacement PR keeps the same lobby joinability fix on the correctly named branch:

- Replacement PR: #172
- Replacement branch: `issue-165-lobby-joinable`
- Issue covered by replacement: #165
