### PR TITLE
Report denied lobby joins as failures

### DIFF
--- a/docs/lobbies.js
+++ b/docs/lobbies.js
@@ -248,8 +248,9 @@
  * @event steam
  * @member {string} event_type The string value `"lobby_joined"`
  * @member {int64} lobby_id The lobby unique identifier
- * @member {boolean} success Whether or not the task was successful
+ * @member {boolean} success Whether or not the lobby was entered successfully
  * @member {real} result The code of the result
+ * @member {real} enter_response The Steam `EChatRoomEnterResponse` value returned for the join attempt
  * @event_end
  * 
  * @event steam

--- a/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_matchmaking.cpp
+++ b/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_matchmaking.cpp
@@ -405,10 +405,18 @@ YYEXPORT void /*double*/ steam_lobby_list_get_lobby_member_id(RValue & Result, C
 
 CCallResult<steam_net_callbacks_t, LobbyEnter_t> steam_lobby_joined;
 void steam_net_callbacks_t::lobby_joined(LobbyEnter_t* e, bool failed) {
-	steam_lobby_current.SetFromUint64(e->m_ulSteamIDLobby);
+	int32 enterResponse = failed ? k_EChatRoomEnterResponseError : e->m_EChatRoomEnterResponse;
+	bool success = !failed && enterResponse == k_EChatRoomEnterResponseSuccess;
+	uint64 lobbyId = failed ? 0 : e->m_ulSteamIDLobby;
+	if (success)
+	{
+		steam_lobby_current.SetFromUint64(lobbyId);
+	}
+
 	steam_net_event q((char*)"lobby_joined");
-	q.set_uint64_all("lobby_id", e->m_ulSteamIDLobby);
-	q.set_success(!failed);
+	q.set_uint64_all("lobby_id", lobbyId);
+	q.set_success(success);
+	q.set((char*)"enter_response", enterResponse);
 	q.dispatch();
 }
 


### PR DESCRIPTION
Fixes #165.

## Summary
- Treat `LobbyEnter_t` as successful only when Steam reports `k_EChatRoomEnterResponseSuccess`.
- Leave `steam_lobby_current` unchanged when Steam denies the join, such as when the lobby is not joinable.
- Add `enter_response` to the `lobby_joined` async event so callers can inspect Steam's `EChatRoomEnterResponse` value.

## Validation
- `git diff --check`
- Checked Steamworks `ISteamMatchmaking` documentation for `LobbyEnter_t` and `SetLobbyJoinable` behavior.

## Notes
Native build verification is blocked in this checkout by external dependencies: the Steamworks SDK headers are not present locally and the normal macOS build requires the project signing certificate.
