### PR TITLE
Fix UGC tag string lifetime

### DIFF
--- a/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_common.h
+++ b/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_common.h
@@ -4,6 +4,7 @@
 #endif
 
 #include <vector>
+#include <string>
 // Check if NAN is already defined
 #ifndef NAN 
 	// Include the cmath header if NAN is not defined
@@ -33,7 +34,7 @@ extern void _SW_SetArrayOfInt32(RValue* _array, std::vector<int> &values);
 extern void _SW_SetArrayOfInt64(RValue* _array, std::vector<int64> &values);
 extern void _SW_SetArrayOfReal(RValue* _array, std::vector<double> &values);
 extern void _SW_SetArrayOfRValue(RValue* _array, std::vector<RValue> &values);
-extern std::vector<const char*> _SW_GetArrayOfStrings(RValue* arg, int arg_idx, const char* func);
+extern std::vector<std::string> _SW_GetArrayOfStrings(RValue* arg, int arg_idx, const char* func);
 extern std::vector<int32> _SW_GetArrayOfInt32(RValue* arg, int arg_idx, const char* func);
 std::vector<double> _SW_GetArrayOfReal(RValue* arg, int arg_idx, const char* func);
 extern std::vector<uint64> _SW_GetArrayOfUint64(RValue* arg, int arg_idx, const char* func);

--- a/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_ugc.cpp
+++ b/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/GMLSteam/steam_ugc.cpp
@@ -995,11 +995,17 @@ YYEXPORT void /*double*/ steam_ugc_set_item_tags(RValue& Result, CInstance* self
 
 	uint64 _ugcUpdateHandle = (uint64)YYGetInt64(arg, 0);
 
-	std::vector<const char*> tags = _SW_GetArrayOfStrings(arg, 1, "steam_ugc_set_item_tags");
+	std::vector<std::string> tags = _SW_GetArrayOfStrings(arg, 1, "steam_ugc_set_item_tags");
+	std::vector<const char*> tagPointers;
+	tagPointers.reserve(tags.size());
+	for (const std::string& tag : tags)
+	{
+		tagPointers.push_back(tag.c_str());
+	}
 
 	SteamParamStringArray_t params;
-	params.m_nNumStrings = (int) tags.size();
-	params.m_ppStrings = tags.data();
+	params.m_nNumStrings = (int) tagPointers.size();
+	params.m_ppStrings = tagPointers.data();
 
 	bool bResult = SteamUGC()->SetItemTags((UGCUpdateHandle_t)_ugcUpdateHandle, &params);
 	if (!bResult)

--- a/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/dllmain.cpp
+++ b/source/Steamworks_gml/extensions/steamworks/steamworks_cpp/dllmain.cpp
@@ -4,6 +4,7 @@
 #include "Extension_Interface.h"
 #include "YYRValue.h"
 #include "steam_common.h"
+#include <string>
 #include <vector>
 
 YYRunnerInterface gs_runnerInterface;
@@ -45,23 +46,25 @@ void YYStructAddUndefined(RValue* s, const char* key) {
 	FREE_RValue(&v);
 }
 
-std::vector<const char*> _SW_GetArrayOfStrings(RValue* arg, int arg_idx, const char* func)
+std::vector<std::string> _SW_GetArrayOfStrings(RValue* arg, int arg_idx, const char* func)
 {
 	RValue* pV = &(arg[arg_idx]);
 
-	std::vector<const char*> strings;
+	std::vector<std::string> strings;
 
 	if (KIND_RValue(pV) == VALUE_ARRAY)
 	{
-		RValue elem;
+		RValue elem{};
 		for (int i = 0; GET_RValue(&elem, pV, NULL, i); ++i)
 		{
 			if (KIND_RValue(&elem) != VALUE_STRING)
 			{
-				YYError("%s argument %d [array element %d] incorrect type (%s) expecting a String", func, (arg_idx + 1), i, KIND_NAME_RValue(pV));
+				YYError("%s argument %d [array element %d] incorrect type (%s) expecting a String", func, (arg_idx + 1), i, KIND_NAME_RValue(&elem));
 			}
 
-			strings.push_back(elem.GetString());
+			strings.emplace_back(elem.GetString());
+			FREE_RValue(&elem);
+			elem = {};
 		}
 	}
 	else {
@@ -221,4 +224,3 @@ void _SW_SetArrayOfInt64(RValue* _array, std::vector<int64> &values)
 		FREE_RValue(&tag);
 	}
 }
-


### PR DESCRIPTION
Fixes #166.

## Summary
- Copy GML array string elements into owned `std::string` values instead of returning pointers into temporary `RValue` storage.
- Build the `SteamParamStringArray_t` pointer list from those owned strings for the lifetime of the `SetItemTags` call.
- Avoid mutating or corrupting unrelated GML array data while preparing UGC tags.

## Validation
- `git diff --check`
- `xcodebuild -list -project source/Steamworks_gml/extensions/steamworks/steamworks_macos/Steamworks.xcodeproj`
- Attempted native macOS build with `CODE_SIGNING_ALLOWED=NO`; compilation is blocked because `source/Steamworks_sdk/steam_api.h` is not present in this checkout.

## Notes
The normal Xcode build is also blocked locally by the missing Mac Development signing certificate.
