### PR TITLE
Document GMRT support status

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ In order to compile for Windows/macOS/Linux you are required to [download the St
 > * `steam_user_get_auth_session_ticket` can no longer be used for HTTP Web API purposes, this is now only for Game Server authentication (NOT HTTP, this is related to Steam Networking).
 > * `steam_user_get_auth_ticket_for_web_api` must now be used for HTTP Web API, along with the identity parameter (not required but heavily recommended by Valve)
 
+> [!NOTE]
+> The 2.x extension targets the GMS2 runtime. LTS2026 GMRT support is planned for a future v3.0.0 release and is expected to require project code changes because the extension API will not be a drop-in replacement.
+
 ## Documentation
 
 * Check [the documentation](../../wiki)
@@ -34,4 +37,3 @@ The online documentation is regularly updated to ensure it contains the most cur
 We encourage users to refer primarily to the GitHub Wiki for the latest information and updates. The HTML version, included with the extension and within the demo project's data files, serves as a secondary, static reference.
 
 Additionally, if you're contributing new features through PR (Pull Requests), we kindly ask that you also provide accompanying documentation for these features, to maintain the comprehensiveness and usefulness of our resources.
-

--- a/docs/guides.md
+++ b/docs/guides.md
@@ -34,6 +34,12 @@ To use the Steam API extension you should follow these steps:
     - 1: Show errors and warnings (recommended)
     - 2: Show everything (use before submitting a bug)
 
+## Runtime Support
+
+This 2.x version of the Steamworks extension is intended for the GMS2 runtime targets. Do not treat it as a drop-in compatible package for LTS2026 GMRT targets.
+
+[[WARNING: GMRT support is planned for a future v3.0.0 release of the extension. That release is expected to include breaking API changes, so existing projects will need code changes when moving from the 2.x API to the GMRT-compatible API.]]
+
 # Migration Changes
 
   During the migration of the Steamworks function library from the base GameMaker runner into this extension, there were some new functions that were added, and others that were slightly changed. This document covers the changes that happened during that migration.


### PR DESCRIPTION
Related issue: #164.

## Summary
- Add a runtime-support note to the setup guide for the current 2.x extension line.
- Add the same warning to the README requirements section.
- Make clear that LTS2026 GMRT support is not a drop-in target for this API line and is expected to arrive in a future v3.0.0 release with breaking API changes.

## Scope
This PR is documentation-only. The full GMRT support requested in issue 164 requires the larger v3 extension/runtime work described by the maintainers, so this PR intentionally leaves that implementation issue open.

## Validation
- `git diff --check`
- `xcodebuild -list -project source/Steamworks_gml/extensions/steamworks/steamworks_macos/Steamworks.xcodeproj`
